### PR TITLE
split MG CI jobs

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -48,12 +48,9 @@ jobs:
             roles/cobertura.xml
             utils/cobertura.xml
 
-  message-generator-test:
+  setup-mg-test:
     needs: tarpaulin-test
-
-    name: MG Test
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -70,96 +67,155 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+  bad-pool-config-test:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run bad-pool-config-test
         run: sh ./test/message-generator/test/bad-pool-config-test/bad-pool-config-test.sh
 
+  interop-jd-translator:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run interop-jd-translator
         run: sh ./test/message-generator/test/interop-jd-translator/interop-jd-translator.sh
 
-          #- name: Run interop-jdc-change-upstream
-          #  run: sh ./test/message-generator/test/interop-jdc-change-upstream/interop-jdc-change-upstream.sh
-
+  interop-proxy-with-multi-ups:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run interop-proxy-with-multi-ups
         run: sh ./test/message-generator/test/interop-proxy-with-multi-ups/interop-proxy-with-multi-ups.sh
 
+  interop-proxy-with-multi-ups-extended:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run interop-proxy-with-multi-ups-extended
         run: sh ./test/message-generator/test/interop-proxy-with-multi-ups-extended/interop-proxy-with-multi-ups-extended.sh
 
+  jds-do-not-fail-on-wrong-tsdatasucc:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run jds-do-not-fail-on-wrong-tsdatasucc
         run: sh ./test/message-generator/test/jds-do-not-fail-on-wrong-tsdatasucc/jds-do-not-fail-on-wrong-tsdatasucc.sh
 
+  jds-do-not-panic-if-jdc-close-connection:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run jds-do-not-panic-if-jdc-close-connection
         run: sh ./test/message-generator/test/jds-do-not-panic-if-jdc-close-connection/jds-do-not-panic-if-jdc-close-connection.sh
 
+  jds-do-not-stackoverflow-when-no-token:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run jds-do-not-stackoverflow-when-no-token
         run: sh ./test/message-generator/test/jds-do-not-stackoverflow-when-no-token/jds-do-not-stackoverflow-when-no-token.sh
 
+  pool-sri-test-1-standard:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run pool-sri-test-1-standard
         run: sh ./test/message-generator/test/pool-sri-test-1-standard/pool-sri-test-1-standard.sh
 
+  pool-sri-test-close-channel:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run pool-sri-test-close-channel
         run: sh ./test/message-generator/test/pool-sri-test-close-channel/pool-sri-test-close-channel.sh
 
+  pool-sri-test-extended_0:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run pool-sri-test-extended_0
         run: sh ./test/message-generator/test/pool-sri-test-extended_0/pool-sri-test-extended_0.sh
 
+  pool-sri-test-extended_1:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run pool-sri-test-extended_1
         run: sh ./test/message-generator/test/pool-sri-test-extended_1/pool-sri-test-extended_1.sh
 
+  pool-sri-test-reject-auth:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run pool-sri-test-reject-auth
         run: sh ./test/message-generator/test/pool-sri-test-reject-auth/pool-sri-test-reject-auth.sh
 
+  standard-coverage:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run standard-coverage
         run: sh ./test/message-generator/test/standard-coverage-test/standard-coverage-test.sh
 
+  sv1-test:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run sv1-test
         run: sh ./test/message-generator/test/sv1-test/sv1-test.sh
 
+  translation-proxy-broke-pool:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run translation-proxy-broke-pool
         run: sh ./test/message-generator/test/translation-proxy-broke-pool/translation-proxy-broke-pool.sh
 
+  translation-proxy:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run translation-proxy
         run: sh ./test/message-generator/test/translation-proxy/translation-proxy.sh
 
+  translation-proxy-old-share:
+    needs: setup-mg-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - name: Run translation-proxy-old-share
         run: sh ./test/message-generator/test/translation-proxy-old-share/translation-proxy-old-share.sh
-
-      - name: Coverage report
-        run: sh ./scripts/code-coverage-report.sh
-
-      - name: Archive MG code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: 'target/*.xml'
-
-      - name: Archive log files
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: logs
-          path: './utils/message-generator/*.log'
-
-            # codecov:
-            #   needs: message-generator-test
-
-            #   name: Codecov Upload
-            #   runs-on: ubuntu-latest
-
-            #   steps:
-
-            #     - name: Checkout repository
-            #       uses: actions/checkout@v4
-
-            #     - name: Download all workflow run artifacts
-            #       uses: actions/download-artifact@v4
-
-            #     - name: Display structure of downloaded files
-            #       run: ls -R
-
-            #     - name: Upload to codecov.io
-            #       uses: codecov/codecov-action@v3
-            #       with:
-            #         files: coverage-report/*.xml, tarpaulin-report/*.xml
-            #         fail_ci_if_error: true
-            #         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
this is a paliative solution to the issues we've been facing with MG CI, which makes it slightly less worse by breaking tests into multiple jobs and allowing us to re-run false alarms in a more agile way